### PR TITLE
Improve parsing correctness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde-value = "0.7.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -317,10 +317,12 @@ impl<'de> Deserializer<'de> {
     /// Parse a string until the next unescaped quote
     fn parse_quoted_string(&mut self) -> Result<String> {
         let mut s = String::new();
-        self.advance(1); // we go past the first "
+
+        let starting_quote = self.next_char()?;
+
         loop {
             let mut c = self.next_char()?;
-            if c == '\"' {
+            if c == starting_quote {
                 break;
             } else if c == '\\' {
                 c = match self.next_char()? {
@@ -433,7 +435,7 @@ impl<'de> Deserializer<'de> {
         let v = match ch {
             ',' | ':' | '[' | ']' | '{' | '}' => self.fail(UnexpectedChar),
             '\'' if self.is_at_triple_quote(0) => self.parse_multiline_string(),
-            '"' => self.parse_quoted_string(),
+            '"' | '\'' => self.parse_quoted_string(),
             _ => (if self.accept_quoteless_value {
                 self.parse_quoteless_str()
             } else {

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -1,0 +1,16 @@
+use serde_value::Value;
+
+#[macro_use] mod common;
+
+/// check we fixed the bug #3
+#[test]
+fn test_member_values() {
+    // These values were problematic
+    deser_hjson::from_str::<Value>("{foo:null}").unwrap();
+    deser_hjson::from_str::<Value>("{foo:false}").unwrap();
+    deser_hjson::from_str::<Value>("{foo:true}").unwrap();
+    deser_hjson::from_str::<Value>("{foo:'bar'}").unwrap();
+    // Also check some already working values
+    deser_hjson::from_str::<Value>(r#"{foo:"bar"}"#).unwrap();
+    deser_hjson::from_str::<Value>("{foo:42}").unwrap();
+}

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -14,6 +14,7 @@ fn test_string() {
     }
     assert_eq!(W{c:"test".to_string()}, from_str("{c:test\n}").unwrap());
     assert_eq!(W{c:"test".to_string()}, from_str("{c:\"test\"}").unwrap());
+    assert_eq!(W{c:"test".to_string()}, from_str("{c:'test'}").unwrap());
     assert_eq!(
         W {c:"xterm -e \"vi /some/path\"".to_string()},
         from_str(r#"{


### PR DESCRIPTION
This PR fixes parsing of certain values (see #3).

- The fix for for null and bools includes introducing the `try_parse` parse family of methods which enable backtracking
- The fix for single quote strings involves actually checking for `'` and comparing the starting and ending quotes

Closes #3 