### PR TITLE
Implement `from_reader`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use {
     serde::de,
     std::{
         fmt,
+        io,
         str::Utf8Error,
     },
 };
@@ -42,7 +43,7 @@ pub enum ErrorCode {
     UnexpectedChar,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
 
     /// a Hjson syntax error raised in our code,
@@ -69,6 +70,9 @@ pub enum Error {
     /// an UTF8 error, raised when using from_slice
     /// with an invalid UTF8 slice
     Utf8(Utf8Error),
+
+    /// an IO error, raised when using from_reader
+    Io(io::Error),
 }
 
 impl Error {
@@ -89,6 +93,12 @@ impl From<Utf8Error> for Error {
     }
 }
 
+impl From<io::Error> for Error {
+    fn from(source: io::Error) -> Self {
+        Self::Io(source)
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -102,6 +112,9 @@ impl fmt::Display for Error {
                 write!(formatter, "error message: {:?}", msg)
             }
             Self::Utf8(source) => {
+                source.fmt(formatter)
+            }
+            Self::Io(source) => {
                 source.fmt(formatter)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,40 @@ mod error;
 
 pub use error::*;
 
+/// Deserialize an instance of type `T` from a reader of Hjson text
+///
+/// # Example
+///
+/// ```
+/// use serde::Deserialize;
+/// use std::io::Cursor;
+///
+/// #[derive(Deserialize, Debug)]
+/// struct User {
+///     fingerprint: String,
+///     location: String,
+/// }
+///
+/// // The type of `j` is `Cursor` which implements the `Read` trait
+/// let j = Cursor::new("
+///     fingerprint: 0xF9BA143B95FF6D82
+///     location: Menlo Park, CA
+/// ");
+///
+/// let u: User = deser_hjson::from_reader(j).unwrap();
+/// println!("{:#?}", u);
+/// ```
+pub fn from_reader<R, T>(mut reader: R) -> Result<T>
+where
+    R: std::io::Read,
+    T: serde::de::DeserializeOwned,
+{
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    from_slice(&buf)
+}
+
+
 /// Deserialize an instance of type `T` from bytes of Hjson text
 ///
 /// # Example

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -1,0 +1,21 @@
+use {
+    deser_hjson::from_reader,
+    serde:: Deserialize,
+};
+
+#[macro_use] mod common;
+
+#[test]
+fn test_reader() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Test {
+        a: i32,
+        b: String,
+    }
+    let hjson = br#"{ a: 1, b: "2" }"#;
+    let expected = Test {
+        a: 1,
+        b: "2".to_string(),
+    };
+    assert_eq!(expected, from_reader(&hjson[..]).unwrap());
+}

--- a/tests/serde-error.rs
+++ b/tests/serde-error.rs
@@ -39,6 +39,9 @@ fn test_no_raw_serde_error() {
             Err(e@deser_hjson::Error::Utf8(_)) => {
                 panic!("Unexpected Utf8 Error: {:?}", e);
             }
+            Err(e@deser_hjson::Error::Io(_)) => {
+                panic!("Unexpected Io Error: {:?}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements reader support for `deser-hjson`. People coming from other serde-based deserializers (`serde_json`, `serde_yaml`, etc.) expect this `crate::from_reader(io::Read)` function to exist.

**Breaking API changes:**

- The `Error` enum got a new variant for representing I/O errors. This is a breaking change because the enum was not marked as non-exhaustive.
- Had to drop the `Clone` and `PartialEq` derives from the `Error` enum because the new wrapped `std::io::Error` error does not implement these traits.