### PR TITLE
Fix multiline and quoteless

### DIFF
--- a/src/de_number.rs
+++ b/src/de_number.rs
@@ -1,75 +1,57 @@
 use {
     crate::{
         de::Deserializer,
-        error::{ErrorCode::*, Result},
+        error::{Result},
     },
     serde::de::Visitor,
 };
 
 /// an intermediate representation of number which
-/// are read into undefinite types
-pub(crate) struct Number<'de> {
-    negative: bool,
+/// are read into undefinite types, or a string if it fails
+pub(crate) struct NumberOrString<'de> {
     s: &'de str,
-    has_float_chars: bool,
 }
 
-impl<'de> Number<'de> {
-    /// read the characters of the coming floating point number, without parsing.
-    /// The sign at the start is assumed to have been already read
+impl<'de> NumberOrString<'de> {
+    /// read the characters of the coming (maybe) number, without parsing
     pub fn read<'a>(
         de: &'a mut Deserializer<'de>,
     ) -> Result<Self> {
-        de.eat_shit()?;
-        let mut negative = false;
-        let mut has_float_chars = false;
         for (idx, ch) in de.input().char_indices() {
-            match ch {
-                '0'..='9' => { }
-                '-' if idx == 0 => {
-                    negative = true;
-                }
-                '-' | '+' | '.' | 'e' | 'E' => {
-                    has_float_chars = true;
-                }
-                _ => {
-                    let s = de.start(idx);
-                    de.advance(idx); // we keep the last char
-                    return Ok(Self {
-                        negative, s, has_float_chars
-                    });
-                }
+            let stop = match ch {
+                ',' | ':' | '{' | '}' | '[' | ']' => true,
+                c if c.is_whitespace() => true,
+                _ => false
+            };
+            if stop {
+                let s = de.start(idx);
+                de.advance(idx); // we keep the last char
+                return Ok(Self {s});
             }
         }
         let s = de.take_all();
-        Ok(Self {
-            negative, s, has_float_chars
-        })
+        Ok(Self {s})
     }
     /// deserialize into a relevant number type
     pub fn visit<'a, V>(
         &self,
-        de: &'a mut Deserializer<'de>,
         visitor: V,
     ) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: Visitor<'a>,
     {
-        if self.has_float_chars {
-            // this is a floating point number (or an error)
-            let v: f64 = self.s.parse()
-                .map_err(|_| de.err(ExpectedF64))?;
-            visitor.visit_f64(v)
-        } else if self.negative {
-            // this is a negative integer (or an error)
-            let v: i64 = self.s.parse()
-                .map_err(|_| de.err(ExpectedI64))?;
-            visitor.visit_i64(v)
-        } else {
-            // this is a positive integer (or a number)
-            let v: u64 = self.s.parse()
-                .map_err(|_| de.err(ExpectedU64))?;
+        /* try by starting from the least general */
+        if let Ok(v) = self.s.parse::<u64>() {
             visitor.visit_u64(v)
+        }
+        else if let Ok(v) = self.s.parse::<i64>() {
+            visitor.visit_i64(v)
+        }
+        else if let Ok(v) = self.s.parse::<f64>() {
+            visitor.visit_f64(v)
+        }
+        else {
+            visitor.visit_string(self.s.to_string())
         }
     }
 }

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -1,0 +1,30 @@
+use {deser_hjson::from_str, serde::Deserialize, std::collections::HashMap};
+
+#[macro_use]
+mod common;
+
+#[test]
+fn test_weird_multiline() {
+    // This is testing weird multilines things that are not documented in the spec.
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct W {
+        map: HashMap<String, String>,
+    }
+    let hjson = r#"{
+           a: '''  bla    '''
+           b: '''  bla<empty>
+                  bli<empty>
+                  hello<empty>
+              '''
+   }"#;
+    let some_spaces = "    ";
+    let hjson = hjson.replace("<empty>", some_spaces);
+    println!("input: {:}", hjson);
+    let mut map = HashMap::new();
+    map.insert("a".to_owned(), "bla    ".to_owned());
+    map.insert(
+        "b".to_owned(),
+        "bla".to_owned() + some_spaces + &"\nbli".to_owned() + some_spaces + &"\nhello".to_owned(),
+    );
+    assert_eq!(map, from_str(&hjson).unwrap());
+}

--- a/tests/quoteless-numberlike.rs
+++ b/tests/quoteless-numberlike.rs
@@ -1,0 +1,51 @@
+use serde::Deserialize;
+
+#[macro_use]
+mod common;
+
+#[test]
+fn test_quoteless_number_like() {
+    let hjson = r#"{
+        value: "a"
+        number: 10
+        string: abc
+        hex_but_string: 0x32
+        sameline1_number: 10, sameline1_string: abc
+        sameline2_string1: hello, sameline2_string2: abc
+    }"#;
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Test {
+        value: String,
+        // Certain fields are ignored to force the parser to handle
+        // them without types.
+        sameline1_string: String,
+        sameline2_string2: Option<String>,
+    }
+    let expected = Test {
+        value: "a".to_string(),
+        sameline1_string: "abc".to_string(),
+        sameline2_string2: None,
+    };
+    assert_eq!(expected, deser_hjson::from_str(&hjson).unwrap());
+}
+
+#[test]
+fn test_quoteless_number_like_with_space() {
+    let hjson = r#"{
+        value: "a"
+        string_with_space: 10 apples
+        sameline2_string: 30 19, sameline2_string2: abc
+    }"#;
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Test {
+        value: String,
+        // Certain fields are ignored to force the parser to handle
+        // them without types.
+        sameline2_string2: Option<String>,
+    }
+    let expected = Test {
+        value: "a".to_string(),
+        sameline2_string2: None,
+    };
+    assert_eq!(expected, deser_hjson::from_str(&hjson).unwrap());
+}


### PR DESCRIPTION
The goal of this pull request is to address to areas of the specification that are unclear and not handled well by the parser.
This is all documented in the code but in summary:

- The parser does not handle multilines where text immediately follows ''', like it
```hjson
desc: '''blabla'''
```
or
```hjson
desc: '''blabla
           hello'''
```
There are also so unclear behaviour related to spaces in this case.

- The parser does not handle well quoteless string that look like numbers, such as
```hjson
x: 0x32
```
because it thinks 0x32 is a number. This can happen if the parser has no information on the type and is just trying to skip an entry of a map.

* This also raises some interesting questions that are (again) very unclear in the specification:
```hjson
sameline1_number: 10, sameline1_string: abc
sameline2_string1: hello, sameline2_string2: abc
sameline2_string: 30 19, sameline2_string2: abc
string_with_space: 10 apples
```
Probably the first line should have two fields (that's what the official parser does), but what about the second and third? Since `30 19` is not a number, **AND** quoteless strings can have commas, it should be `sameline2_string` maps to `30 19, sameline2_string2: abc`. The same should happen with `hello` I think. This is what the official parser does anyway.


This PR addresses the first two points. It happens that `sameline1_number: 10, sameline1_string: abc` and `sameline2_string1: hello, sameline2_string2: abc` are parsed "correctly". The last point is not fully address and even though I have added a test for it, **it does not pass with the code in this PR**. For example, `string_with_space: 10 apples` fails to parse.