### PR TITLE
Allow single-quoted identifiers and enum values

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -484,7 +484,7 @@ impl<'de> Deserializer<'de> {
         self.accept_quoteless_value = true;
         let r = match ch {
             ',' | ':' | '[' | ']' | '{' | '}' => self.fail(UnexpectedChar),
-            '"' => self.parse_quoted_string(),
+            '"' | '\'' => self.parse_quoted_string(),
             _ => self.parse_quoteless_identifier().map(|s| s.to_string())
         };
         r
@@ -518,7 +518,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         self.eat_shit()?;
         match self.peek_char()? {
-            '"' => self.deserialize_string(visitor),
+            '"' | '\'' => self.deserialize_string(visitor),
             '0'..='9' | '-' => {
                 let number = Number::read(self)?;
                 number.visit(self, visitor)
@@ -822,7 +822,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         self.eat_shit()?;
         match self.peek_char()? {
-            '"' => {
+            '"' | '\'' => {
                 // Visit a unit variant.
                 visitor.visit_enum(self.parse_quoted_string()?.into_deserializer())
             }

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -15,6 +15,8 @@ fn test_string() {
     assert_eq!(W{c:"test".to_string()}, from_str("{c:test\n}").unwrap());
     assert_eq!(W{c:"test".to_string()}, from_str("{c:\"test\"}").unwrap());
     assert_eq!(W{c:"test".to_string()}, from_str("{c:'test'}").unwrap());
+    assert_eq!(W{c:"test".to_string()}, from_str("{'c':'test'}").unwrap());
+    assert_eq!(W{c:"test".to_string()}, from_str("{\"c\":'test'}").unwrap());
     assert_eq!(
         W {c:"xterm -e \"vi /some/path\"".to_string()},
         from_str(r#"{
@@ -51,4 +53,3 @@ fn test_weird_map_keys() {
     };
     assert_eq!(value, from_str(hjson).unwrap());
 }
-


### PR DESCRIPTION
Hi, thanks for maintaining this crate!

This PR adds single quotes as string-surrounding characters wherever double quotes are allowed.
AFAICT, Hjson allows single-quoted strings to be used anywhere double-quoted strings can: https://hjson.github.io/syntax.html.

The missing cases were identifiers and enum values.